### PR TITLE
Expose getProfileInformation for AJAX handler

### DIFF
--- a/src/main/resources/au/com/funkworks/jmp/mini_profiler.js
+++ b/src/main/resources/au/com/funkworks/jmp/mini_profiler.js
@@ -116,6 +116,7 @@ var MiniProfiler = ( function() {
   }
 
   return {
-    init : init
+    init : init,
+    getProfileInformation : getProfileInformation
   };
 }() );


### PR DESCRIPTION
Some web projects may not use jQuery for making AJAX call
(e.g. Prototype could be used instead). The java-mini-profiler
auto-wires into jQuery, but didn't provide a way for other
AJAX calls to be added to the profile information.

Exposing the getProfileInformation method allows other
AJAX libraries to add AJAX request profile information
to the profiler.
