### PR TITLE
Handle long profile step names better

### DIFF
--- a/src/main/resources/au/com/funkworks/jmp/mini_profiler.html
+++ b/src/main/resources/au/com/funkworks/jmp/mini_profiler.html
@@ -19,10 +19,10 @@
 <script type="text/html" id="@@prefix@@-result-tree-tmpl">
  <li>
  {{if children.length}}
- <div class="name" style="padding-left: ${depth * 18 + 5}px">
- <a href="#" class="expand" id="@@prefix@@-req-profile-${id}">${name}</a> 
+ <div class="name" style="padding-left: ${depth * 18 + 5}px; overflow-x: hidden; white-space: nowrap; text-overflow: ellipsis;">
+ <a href="#" class="expand" title="${name}" id="@@prefix@@-req-profile-${id}">${name}</a>
  {{else}}
- <div class="name" style="padding-left: ${depth * 18 + 23}px">
+ <div class="name" style="padding-left: ${depth * 18 + 23}px; word-wrap: break-word;">
  ${name}
  {{/if}}
  </div><div class="time">${(duration / 1000000).toFixed(2)}


### PR DESCRIPTION
Long profile step names would collide with the timing information
making both unreadable.

For step names that expand, any text that would overflow is
replaced with an ellipsis and a hover text is added with
the full step name.

For step names that don't expand, the text is forced to wrap.

These changes are particularly useful for SQL queries with
text that doesn't wrap, and the AspectJ profiling when
step names include full package, class, and method names.
