### PR TITLE
Respect the context path of an application

### DIFF
--- a/src/main/java/au/com/funkworks/jmp/MiniProfilerFilter.java
+++ b/src/main/java/au/com/funkworks/jmp/MiniProfilerFilter.java
@@ -107,6 +107,11 @@ public class MiniProfilerFilter implements Filter {
 	private String servletURL = "/java_mini_profile/";
 
 	/**
+	 * Context path of the web application
+	 */
+	private String contextPath = "";
+
+	/**
 	 * The number of seconds that profiling data will stick around for in
 	 * memcache.
 	 */
@@ -146,6 +151,9 @@ public class MiniProfilerFilter implements Filter {
 			servletURL = configServletURL;
 			logger.debug("Servlet url configured: {}", servletURL);
 		}
+		contextPath = config.getServletContext().getContextPath();
+		servletURL = contextPath + servletURL;
+
 		String configRestrictToAdmins = config.getInitParameter(RESTRICT_TO_ADMINS_KEY);
 		if (StringUtils.hasLength(configRestrictToAdmins) && Boolean.parseBoolean(configRestrictToAdmins)) {
 			restricted = true;

--- a/src/main/java/au/com/funkworks/jmp/MiniProfilerServlet.java
+++ b/src/main/java/au/com/funkworks/jmp/MiniProfilerServlet.java
@@ -62,7 +62,6 @@ public class MiniProfilerServlet extends HttpServlet {
 	private static final long serialVersionUID = 7906645907029238585L;
 
 	private static final String HTML_ID_PREFIX_KEY = "htmlIdPrefix";
-
 	private static final String RESOURCE_CACHE_HOURS_KEY = "resourceCacheHours";
 
 	private static final String servletURL = "/java_mini_profile/";
@@ -115,7 +114,7 @@ public class MiniProfilerServlet extends HttpServlet {
 
 		resourceLoader = new MiniProfilerResourceLoader();
 		resourceReplacements.put("@@prefix@@", htmlIdPrefix);
-		resourceReplacements.put("@@baseURL@@", servletURL);
+		resourceReplacements.put("@@baseURL@@", config.getServletContext().getContextPath() + servletURL);
 		resourceReplacements.put("@@prefix@@", htmlIdPrefix);
 		logger.debug("Init'ed mini-profiler servlet");
 	}


### PR DESCRIPTION
Applications can be deployed with different context paths. When
a context path is configured, the java-mini-profiler resources
don't get served correctly.

This change respects that context path and serves the resources
correctly.
