### PR TITLE
Disable cache disk overflow

### DIFF
--- a/src/main/java/au/com/funkworks/jmp/cache/NativeEhCacheCacheImpl.java
+++ b/src/main/java/au/com/funkworks/jmp/cache/NativeEhCacheCacheImpl.java
@@ -20,7 +20,7 @@ public class NativeEhCacheCacheImpl implements CacheProfilerService {
 		cache = new Cache(  
 		     new CacheConfiguration("profilerCache", 5000)  
 		       .memoryStoreEvictionPolicy(MemoryStoreEvictionPolicy.LRU)  
-		       .overflowToDisk(true)  
+		       .overflowToDisk(false)
 		       .eternal(false)  
 		       .timeToLiveSeconds(60)  
 		       .timeToIdleSeconds(30)  


### PR DESCRIPTION
Enabling overflow requires consumers to provide
configuration for disk overflow. This is annoying,
and I want it to be easy to use this library.
